### PR TITLE
End game and wave fixes

### DIFF
--- a/src/GUI/GUI.gd
+++ b/src/GUI/GUI.gd
@@ -4,6 +4,7 @@ var scene_path: String
 var days_until_next_asteroid := 0
 var wave := 1
 var waves := 15
+var time_to_boss_impact := 0.0
 
 func _ready() -> void:
 	Signals.connect("game_building_placed", self, "_on_game_building_placed")
@@ -14,6 +15,7 @@ func _ready() -> void:
 	# update our asteroid incoming message
 	Signals.connect("asteroid_wave_timer_updated", self, "_on_asteroid_wave_timer_updated")
 	Signals.connect("asteroid_wave_started", self, "_on_asteroid_wave_started")
+	Signals.connect("asteroid_time_estimate", self, "_on_asteroid_time_estimate")
 
 	# update score gui node
 	Signals.connect("player_score_changed", self, "update_player_score_label")
@@ -47,6 +49,11 @@ func _on_asteroid_wave_timer_updated(time_left: float):
 	set_days_until_next_asteroid((time_left / Constants.seconds_per_day) as int)
 
 
+func _on_asteroid_time_estimate(asteroid_id: int, size: int, time_to_impact: float):
+	if size == 3:
+		time_to_boss_impact = time_to_impact
+		_update_asteroid_wave_message()
+
 func _on_asteroid_wave_started(wave: int, waves: int):
 	if self.wave != wave or self.waves != waves:
 		self.wave = wave
@@ -65,8 +72,8 @@ func set_days_until_next_asteroid(value: int):
 
 func _update_asteroid_wave_message():
 	var header = $TopMenu/Center/VBoxContainer/HeaderLabel
-	if wave == waves:
-		header.text = "FINAL WAVE! SHORE UP YOUR DEFENSES!"
+	if (wave + 1) == waves:
+		header.text = "FINAL WAVE! SHORE UP YOUR DEFENSES! %.1f" % [0.0 if time_to_boss_impact <= 0 else time_to_boss_impact]
 	else:
 		header.text = "Asteroid Wave %s of %s incoming in %s days!" % [wave + 1, waves, days_until_next_asteroid]
 

--- a/src/GUI/GUI.gd
+++ b/src/GUI/GUI.gd
@@ -68,7 +68,7 @@ func _update_asteroid_wave_message():
 	if wave == waves:
 		header.text = "FINAL WAVE! SHORE UP YOUR DEFENSES!"
 	else:
-		header.text = "Asteroid Wave %s of %s incoming in %s days!" % [wave, waves, days_until_next_asteroid]
+		header.text = "Asteroid Wave %s of %s incoming in %s days!" % [wave + 1, waves, days_until_next_asteroid]
 
 
 func _input(event: InputEvent) -> void:

--- a/src/GUI/GUI.tscn
+++ b/src/GUI/GUI.tscn
@@ -49,6 +49,8 @@ mouse_filter = 2
 mouse_filter = 2
 alignment = 0
 label = "Score"
+value = "0"
+color = Color( 1, 1, 1, 1 )
 
 [node name="Center" type="MarginContainer" parent="TopMenu"]
 margin_left = 204.0
@@ -93,6 +95,9 @@ margin_left = 126.0
 margin_right = 190.0
 mouse_filter = 2
 alignment = 0
+label = "Day"
+value = "0"
+color = Color( 1, 1, 1, 1 )
 
 [node name="BottomMenu" type="HBoxContainer" parent="."]
 anchor_top = 1.0
@@ -138,6 +143,7 @@ margin_left = 425.0
 margin_right = 553.0
 margin_bottom = 128.0
 mouse_filter = 1
+building = 0
 
 [node name="GameBuildingButton2" parent="BottomMenu/Center/VBoxContainer/BuildingButtons" instance=ExtResource( 1 )]
 margin_left = 557.0
@@ -220,6 +226,9 @@ mouse_filter = 2
 
 [node name="PlayerGive1" parent="BottomMenu/Right/VBoxContainer/OtherPlayerStats/VBoxContainer" instance=ExtResource( 12 )]
 margin_right = 306.0
+player_num = 2
+player_name = "Bit Buckets"
+resource_give_amount = 1
 
 [node name="PlayerGive2" parent="BottomMenu/Right/VBoxContainer/OtherPlayerStats/VBoxContainer" instance=ExtResource( 12 )]
 modulate = Color( 0.262745, 0.643137, 0.243137, 1 )
@@ -228,6 +237,7 @@ margin_right = 306.0
 margin_bottom = 212.0
 player_num = 3
 player_name = "The Buhlian Operators"
+resource_give_amount = 1
 
 [node name="PlayerGive3" parent="BottomMenu/Right/VBoxContainer/OtherPlayerStats/VBoxContainer" instance=ExtResource( 12 )]
 modulate = Color( 0.552941, 0.160784, 0.796078, 1 )
@@ -236,6 +246,7 @@ margin_right = 306.0
 margin_bottom = 320.0
 player_num = 4
 player_name = "Javawockies"
+resource_give_amount = 1
 
 [node name="PlayerGive4" parent="BottomMenu/Right/VBoxContainer/OtherPlayerStats/VBoxContainer" instance=ExtResource( 12 )]
 modulate = Color( 0.721569, 0.52549, 0.156863, 1 )
@@ -244,6 +255,7 @@ margin_right = 306.0
 margin_bottom = 428.0
 player_num = 5
 player_name = "Alumiboti"
+resource_give_amount = 1
 [connection signal="selected" from="BottomMenu/Center/VBoxContainer/BuildingButtons/GameBuildingButton" to="." method="_on_GameBuildingButton_selected"]
 [connection signal="selected" from="BottomMenu/Center/VBoxContainer/BuildingButtons/GameBuildingButton2" to="." method="_on_GameBuildingButton_selected"]
 [connection signal="selected" from="BottomMenu/Center/VBoxContainer/BuildingButtons/GameBuildingButton3" to="." method="_on_GameBuildingButton_selected"]

--- a/src/GameObjects/Asteroids/Asteroid.gd
+++ b/src/GameObjects/Asteroids/Asteroid.gd
@@ -46,6 +46,9 @@ func _on_asteroid_position_updated(asteroid_id: int, position: Vector2):
 
 func update_asteroid_position(position: Vector2):
 	asteroid.position = position
+	# let any interested parties know how long we have left
+	var distance_remaining: float = (impact_point.position - asteroid.position).length()
+	Signals.emit_signal("asteroid_time_estimate", id, size, distance_remaining / speed)
 
 func _on_ImpactPoint_area_entered(area):
 	if get_tree().is_network_server():

--- a/src/GameObjects/Asteroids/AsteroidManager.gd
+++ b/src/GameObjects/Asteroids/AsteroidManager.gd
@@ -32,17 +32,11 @@ func _ready():
 		# if we are network server and the server is already started, start the timer
 		$Timer.start(initial_wave_time)
 		Signals.emit_signal("asteroid_wave_timer_updated", $Timer.time_left)
-
-func _on_server_started():
-	if get_tree().is_network_server():
-		print("Starting asteroid waves")
-		# only start the timer to spanw new waves if we are the server
-		$Timer.start(initial_wave_time)
-		Signals.emit_signal("asteroid_wave_timer_updated", $Timer.time_left)
+		Signals.emit_signal("asteroid_wave_started", wave, waves)
 
 func _on_Timer_timeout():
 	wave += 1
-	if wave < waves or waves == -1:
+	if wave < (waves - 1) or waves == -1:
 		$Timer.start(base_wave_time * rand_range(0.25,2))
 		Signals.emit_signal("asteroid_wave_timer_updated", $Timer.time_left)
 	if wave == waves:

--- a/src/GameObjects/Asteroids/AsteroidManager.gd
+++ b/src/GameObjects/Asteroids/AsteroidManager.gd
@@ -40,8 +40,12 @@ func _on_Timer_timeout():
 		$Timer.start(base_wave_time * rand_range(0.25,2))
 		Signals.emit_signal("asteroid_wave_timer_updated", $Timer.time_left)
 	if wave == waves:
+		print_debug("FINAL WAVE")
 		final_wave()
 
+	if wave > waves:
+		print_debug("whoops, we called our timer again after our waves are done")
+		return
 	Signals.emit_signal("asteroid_wave_started", wave, waves)
 
 	asteroid_count += wave + asteroid_quantity_modifier
@@ -110,10 +114,12 @@ func _on_dwarf_planet_destroyed():
 
 func final_wave():
 	var boss = dwarf_planet.instance()
+	boss.id = num_asteroids
+	active_asteroids += 1
+	num_asteroids += 1
 	for territory in territories:
 		if PlayersManager.get_player(territory.territory_owner).ai_controlled == false:
 			boss.global_position = territory.center_global
-			active_asteroids += 1
 			break
 	add_child(boss)
 	# after this asteroid is setup, send it to the clients

--- a/src/GameObjects/DefenseBuildings/ShieldArea.gd
+++ b/src/GameObjects/DefenseBuildings/ShieldArea.gd
@@ -60,6 +60,9 @@ func damage(damage):
 	if health <= 0:
 		disable()
 	$AsteroidStrikeAudio.play()
+	
+	# we survived! give us points
+	PlayersManager.get_player(get_owner().player_num).add_score("asteroid_deflected")
 	if get_tree().is_network_server():
 		RPC.send_shield_damaged(get_parent().building_id, damage)
 

--- a/src/GameObjects/DefenseBuildings/ShieldBuilding.gd
+++ b/src/GameObjects/DefenseBuildings/ShieldBuilding.gd
@@ -43,6 +43,4 @@ func _on_Shield_mouse_exited():
 		$ShieldArea/Sprite.set_modulate(Color(1,1,1,0.25))
 		
 func _on_day_passed(day):
-	if(not active):
-		PlayersManager.get_player(player_num).add_score("asteroid_deflected")
 	tech_check()

--- a/src/Map/Map.gd
+++ b/src/Map/Map.gd
@@ -133,5 +133,6 @@ func _on_impact_registered(target, area):
 				var child = node.get_child(0)
 				if child is Territory:
 					child.set_type(Enums.territory_types.destroyed)
+					Signals.emit_signal("territory_destroyed", child)
 
 

--- a/src/Singletons/Server.gd
+++ b/src/Singletons/Server.gd
@@ -37,7 +37,9 @@ func reset_values():
 	day = 0
 	single_player = false
 	started = false
+	timer.stop()
 	timer.wait_time = Constants.seconds_per_day
+
 
 # A new player has connected to the game
 func _player_connected(id):
@@ -111,10 +113,14 @@ func _on_asteroid_wave_started(wave: int, waves: int):
 
 
 func _on_final_wave_complete():
+	reset_values()
+	RPC.send_players_updated(PlayersManager.get_all_player_dicts())
 	RPC.send_final_wave_complete()
 
 
 func _on_loser():
+	reset_values()
+	RPC.send_players_updated(PlayersManager.get_all_player_dicts())
 	RPC.send_loser()
 
 

--- a/src/Singletons/Signals.gd
+++ b/src/Singletons/Signals.gd
@@ -50,6 +50,7 @@ signal dwarf_planet_destroyed()
 signal asteroid_incoming(position, asteroid_strength, attributes)
 signal asteroid_position_updated(asteroid_id, position)
 signal final_wave_complete()
+signal territory_destroyed(territory)
 
 signal shield_update(building_id, active)
 signal shield_damaged(building_id, damage)

--- a/src/Singletons/Signals.gd
+++ b/src/Singletons/Signals.gd
@@ -49,6 +49,7 @@ signal asteroid_destroyed(asteroid_id, position, size)
 signal dwarf_planet_destroyed()
 signal asteroid_incoming(position, asteroid_strength, attributes)
 signal asteroid_position_updated(asteroid_id, position)
+signal asteroid_time_estimate(astero_id, size, time_to_impact)
 signal final_wave_complete()
 signal territory_destroyed(territory)
 

--- a/src/VFX/Smoke.tscn
+++ b/src/VFX/Smoke.tscn
@@ -35,7 +35,7 @@ scale_random = 0.5
 scale_curve = SubResource( 4 )
 color_ramp = SubResource( 2 )
 
-[sub_resource type="Animation" id=17]
+[sub_resource type="Animation" id=6]
 length = 3.0
 loop = true
 step = 0.05
@@ -67,4 +67,4 @@ texture = ExtResource( 4 )
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 autoplay = "Explode"
-anims/Explode = SubResource( 17 )
+anims/Explode = SubResource( 6 )

--- a/src/World.tscn
+++ b/src/World.tscn
@@ -32,4 +32,8 @@ rect_min_size = Vector2( 1920, 1080 )
 visible = false
 
 [node name="AsteroidManager" parent="." instance=ExtResource( 5 )]
+
+[node name="EndGameDelayTimer" type="Timer" parent="."]
+wait_time = 5.0
+one_shot = true
 [connection signal="visibility_changed" from="CanvasLayer/TechTree" to="CanvasLayer/TechTree" method="_on_show"]


### PR DESCRIPTION
* Fixed wave count to include final wave, i.e. wave 15 of 15 is the final wave
* Removed stuff to start asteroid waves for test server starts
* Adding deflect score in shield deflection rather than at day end (so end game score is accurate)
* Created territory_destroyed event so we don't have to loop over all territories each time to check for end game
* Sending player dicts to clients one last time when game over
* Only calling lose_game() and win_game() once
* Made sure player with highest score worked for networked player
Also Added final asteroid COUNTDOWN